### PR TITLE
Fix typo in apt command in QEMU section

### DIFF
--- a/hugo/content/tools/_index.md
+++ b/hugo/content/tools/_index.md
@@ -80,9 +80,8 @@ that assumes a working rootless Podman setup and `socat` installed. It
 currently only works on a Linux system (specifically, it does not work
 when containers are run in Podman's virtual machine, which is required
 on MacOS and Windows). On Ubuntu 22.10, running `apt install podman
-rootlesskit Ubuntu 22.10, running `apt install podman rootlesskit
-slirp4netns socat` should be enough. Then you can just run the script
-like:
+rootlesskit slirp4netns socat` should be enough. Then you can just run 
+the script like:
 
 ```
 ./contrib/run-tkey-qemu


### PR DESCRIPTION
Current text is:
>  On Ubuntu 22.10, running apt install podman rootlesskit Ubuntu 22.10, running apt install podman rootlesskit slirp4netns socat should be enough. Then you can just run the script like:

Should be:
> On Ubuntu 22.10, running apt install podman rootlesskit slirp4netns socat should be enough. Then you can just run the script like: