### PR TITLE
Remove direct mention of -apps repo & revise

### DIFF
--- a/hugo/content/devapp/_index.md
+++ b/hugo/content/devapp/_index.md
@@ -102,9 +102,6 @@ programming of an unprovisioned TKey, see:
 [quickstart.md](https://github.com/tillitis/tillitis-key1/blob/main/doc/quickstart.md)
 (in the tillitis-key1 repository).
 
-The examples below refer to files in the
-[tillitis-key1-apps repository](https://github.com/tillitis/tillitis-key1-apps).
-
 ### Users on Linux
 
 Running `lsusb` should list the USB stick as `1207:8887 Tillitis

--- a/hugo/content/devapp/_index.md
+++ b/hugo/content/devapp/_index.md
@@ -169,8 +169,8 @@ There should be an entry with `"USB Vendor Name" = "Tillitis"`.
 ### Running a TKey Device Application
 
 You can use `tkey-runapp` from the
-[tillitis-key1-apps](https://github.com/tillitis/tillitis-key1-apps)
-repository to load a device application onto the TKey.
+[tkey-devtools](https://github.com/tillitis/tkey-devtools) repository
+to load a device application onto the TKey.
 
 ```
 $ tkey-runapp apps/blink/app.bin

--- a/hugo/content/intro/_index.md
+++ b/hugo/content/intro/_index.md
@@ -78,7 +78,6 @@ security-critical operations.
 
 ## Getting Started
 
-* [tillitis-key1-apps repository](https://github.com/tillitis/tillitis-key1-apps),
-  with TKey client and device applications.
+* [Get started using your TKey](https://tillitis.se/getstarted).
 * [Tools & Libraries](../tools/), setup and introduction for
   application developers.

--- a/hugo/content/memory/_index.md
+++ b/hugo/content/memory/_index.md
@@ -51,8 +51,8 @@ The first 8 bits in a 32-bit address.
 ## MMIO
 
 MMIO begins at `0xc000_0000` but please use the constants in
-[tk1_mem.h](https://github.com/tillitis/tillitis-key1-apps/blob/main/apps/include/tk1_mem.h)
-(in the tillitis-key1-apps repository).
+[tk1_mem.h](https://github.com/tillitis/tkey-libs/blob/main/include/tk1_mem.h)
+in the `tkey-libs` repository.
 
 *Note*: MMIO accesses should be 32 bits wide. Use for example `lw` and
 `sw` to load and store 32-bit words. Exceptions are `FW_RAM` and

--- a/hugo/content/projects/_index.md
+++ b/hugo/content/projects/_index.md
@@ -24,6 +24,7 @@ This page can be used both as inspiration and to find useful use cases for your 
 - [Verification tool for your TKey](https://tillitis.se/app/tkey-device-verification/)
 - [Go package to communicate with a TKey](https://github.com/tillitis/tkeyclient)
 - [Go package to communicate with the Ed25519 signer oracle](https://github.com/tillitis/tkey-verification)
+- [TKey Development tools](https://github.com/tillitis/tkey-devtools).
 - [Signed random data generator](https://github.com/tillitis/tkey-random-generator)
 - [age plugin using TKey](https://github.com/quite/age-plugin-tkey)
 - [Cryptum: Encrypted file storage](https://github.com/0xMihir/Cryptum)

--- a/hugo/content/tools/_index.md
+++ b/hugo/content/tools/_index.md
@@ -74,17 +74,20 @@ MiB):
 ghcr.io/tillitis/tkey-qemu-tk1-23.03.1:latest
 ```
 
-We provide a script in
-[tillitis-key1-apps](https://github.com/tillitis/tillitis-key1-apps)
-that assumes a working rootless Podman setup and `socat` installed. It
+We provide a script `run-tkey-qemu` that runs this image and binds the
+serial port to a pty called `tkey-qemu-pty` in the current directory.
+
+You can find `run-tkey-qemu` in the
+[tkey-devtools](https://github.com/tillitis/tkey-devtools) repo. It
+assumes a working rootless Podman setup and `socat` installed. It
 currently only works on a Linux system (specifically, it does not work
 when containers are run in Podman's virtual machine, which is required
 on MacOS and Windows). On Ubuntu 22.10, running `apt install podman
-rootlesskit slirp4netns socat` should be enough. Then you can just run 
+rootlesskit slirp4netns socat` should be enough. Then you can just run
 the script like:
 
 ```
-./contrib/run-tkey-qemu
+./run-tkey-qemu
 ```
 
 This will let you run client apps with `--port ./tkey-qemu-pty` and it

--- a/hugo/content/tools/_index.md
+++ b/hugo/content/tools/_index.md
@@ -7,11 +7,11 @@ weight: 2
 
 ## Introduction
 
-To build you can either use our OCI images or use native tools on your
-dev box.
+To build applications you can either use our OCI images or use native
+tools on your dev box.
 
-If want your device applications not to change, which as you know also
-means changing that application's CDI as explained in [the
+If you want your device applications not to change, which as you know
+also means changing that application's CDI as explained in [the
 introduction](intro/), it might be better to use the OCI images. At
 the very least you want to be sure that the versions of the compiler
 and other tools you use stays the same. Perhaps pin those packages if
@@ -63,7 +63,7 @@ $ podman pull ghcr.io/tillitis/tkey-builder:2
 contains all the tools necessary to build the FPGA bitstream and the
 firmware.
 
-## QEMU
+## QEMU Emulator
 
 Tillitis provides a TKey emulator based on QEMU.
 
@@ -160,55 +160,45 @@ if you have Podman installed.
 
 ## Client libraries
 
-We provide two Go packages to help in developing client applications.
+We provide some Go packages to help in developing client applications.
 What we call "client" is the computer or mobile device you insert your
 TKey into.
 
-- `github.com/tillitis/tkeyclient`: Contains functions to connect to,
-  load and start a device application on the TKey. - [Go
+- [github.com/tillitis/tkeyclient](https://github.com/tillitis/tkeyclient):
+  Contains functions to connect to, load and start a device
+  application on the TKey. [Go
   doc](https://pkg.go.dev/github.com/tillitis/tkeyclient).
-- `github.com/tillitis/tkeysign`: Contains functions to communicate
-  with the `signer` device app, an ed25519 signing oracle. [Go
+- [github.com/tillitis/tkeyutil](https://github.com/tillitis/tkeyutil):
+  Utility functions input the USS or send notifications. [Go
+  doc](https://pkg.go.dev/github.com/tillitis/tkeyutil).
+- [github.com/tillitis/tkeysign](https://github.com/tillitis/tkeysign):
+  Contains functions to communicate with the `signer` device app, an
+  ed25519 signing oracle. [Go
   doc](https://pkg.go.dev/github.com/tillitis/tkeysign).
-
-## Our TKey Client and Device Apps
-
-We provide some client and device apps in the
-[tillitis-key1-apps](https://github.com/tillitis/tillitis-key1-apps)
-GitHub repository.
-
-First clone and build the device libraries [as explained above](#device-libraries).
-
-Execute the following command to clone the repository:
-
-```
-$ git clone https://github.com/tillitis/tillitis-key1-apps.git
-$ cd tillitis-key1-apps
-```
-
-Again you have the choice of building with host tools or an OCI image.
 
 ### Building with host tools
 
-Execute the following command to build all TKey client and device
-applications:
+Most of the apps listed under [projects](/projects/) comes with a
+Makefile and can be built with a simple:
 
 ```
 $ make
 ```
 
+If they have complex dependencies they might come with a `build.sh`
+script to clone and build the dependencies first.
+
 If you cloned and built the tkey-libs somewhere else than in a
-directory called `tkey-libs` next to `tillitis-key1-apps` you need to
-provide the path relative to `tillitis-key1-apps/apps`, for instance:
+directory called `tkey-libs` next to the app directory you might need
+to specify a path to it, for example:
 
 ```
-$ make LIBDIR=../../tkey-libs-main
+$ make LIBDIR=../tkey-libs-main
 ```
 
 If your available `objcopy` is anything other than the default
 `llvm-objcopy`, then define `OBJCOPY` to whatever they're called on
 your system.
-
 
 TKey device applications can run both on the real hardware TKey and in
 the QEMU emulator. In both cases, the client application (for example
@@ -218,15 +208,14 @@ device apps in QEMU.
 
 ### Building with `tkey-builder`
 
-To build everything in the apps repo:
+Most of the [projects](/projects/) come with a `podman` target:
 
 ```
-$ git clone https://github.com/tillitis/tillitis-key1-apps
-$ cd tillitis-key1-apps
 $ make podman
 ```
 
-Or use podman directly if you haven't got `make` installed:
+Or use podman directly if you haven't got `make` installed, typically
+specifying where your `tkey-libs` are:
 
 ```
 $ podman run --rm --mount type=bind,source=.,target=/src --mount type=bind,source=../tkey-libs,target=/tkey-libs -w /src -it ghcr.io/tillitis/tkey-builder:1 make -j


### PR DESCRIPTION
- `tk1_mem.h` is not in -apps anymore   
- tkey-runapp and the run qemu script now in tkey-devtools.
- Rewrite build instructions based on general convenations instead of explicitly naming -apps and how builds work there.