### PR TITLE
Library .a files on top level in tkey-libs

### DIFF
--- a/hugo/content/devapp/_index.md
+++ b/hugo/content/devapp/_index.md
@@ -175,7 +175,7 @@ $ tkey-runapp rgb.bin
 
 This should auto-detect any attached TKeys, upload, and start a tiny
 device app that blinks the LED as described under [Device
-Applications](#device-applications).
+Applications](/devapp/#device-applications).
 
 ### Debugging
 

--- a/hugo/content/devapp/_index.md
+++ b/hugo/content/devapp/_index.md
@@ -58,7 +58,7 @@ $ clang -g -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 \
 $ clang -g -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 \
   -mcmodel=medany -static -ffast-math -fno-common -nostdlib \
   -T ../tkey-libs/app.lds \
-  -L ../tkey-libs/libcrt0/ -lcrt0 -L ../../tkey-libs/libcommon -lcommon \
+  -L ../tkey-libs -lcrt0 -lcommon \
   -I ../tkey-libs -o rgb.elf rgb.o
 
 $ llvm-objcopy --input-target=elf32-littleriscv --output-target=binary rgb.elf rgb.bin


### PR DESCRIPTION
Compilation flag changes if the .a files are on top level.

Please see https://github.com/tillitis/tkey-libs/pull/14