### PR TITLE
Add macOS instructions to toolchain

### DIFF
--- a/hugo/content/devapp/_index.md
+++ b/hugo/content/devapp/_index.md
@@ -11,7 +11,7 @@ Consider this C program:
 
 ```c
 #include <stdint.h>
-#include <led.h>
+#include <tkey/led.h>
 
 #define SLEEPTIME 100000
 

--- a/hugo/content/tools/_index.md
+++ b/hugo/content/tools/_index.md
@@ -25,8 +25,9 @@ required (with riscv32 support and the Zmmul extension,
 `-march=rv32iczmmul`). Packages on Ubuntu 22.10 (Kinetic) are known to
 work.
 
-On Ubuntu, you can install the required packages with the following
-command:
+### Linux
+Packages on Ubuntu 22.10 (Kinetic) are known to work. You can install
+the required packages with the following command:
 
 ```
 sudo apt install build-essential clang lld llvm bison flex libreadline-dev \
@@ -40,11 +41,43 @@ sudo apt install build-essential clang lld llvm bison flex libreadline-dev \
                  golang clang-format
 ```
 
-On Windows, the easiest way to install the required packages is
-through the package manager
-[Chocolatey](https://community.chocolatey.org/). After installing
-Chocolatey, run Powershell (version 3 or higher) as an administrator,
-and install the necessary packages using the following command:
+### macOS
+First you need the Xcode Command Line Tools installed.
+
+```
+xcode-select --install
+```
+
+This will give you `make` and other useful tools for development. Even
+if macOS provides `llvm` it does not seem to support our target,
+`riscv32-unknown-none-elf`. Hence we recommend to also installing
+`llvm`, among other packages, via brew.
+
+```
+brew install llvm go
+```
+
+One caveat for llvm is that it is "keg-only", which means it was not
+symlinked into `/opt/homebrew`, and we then need to do it ourselves.
+
+The esiest way is to add
+
+```
+export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+```
+
+to your your `.zshrc` or equvivalent. The key is that we add `llvm`
+from brew in `PATH` before `llvm` provided by macOS. Just remember
+that if you use `llvm` provided by macOS for other projetcs this can
+create issues. Another way would be to explicitly specify which to use
+in the makefiles.
+
+### Windows
+The easiest way to install the required packages is through the
+package manager [Chocolatey](https://community.chocolatey.org/). After
+installing Chocolatey, run Powershell (version 3 or higher) as an
+administrator, and install the necessary packages using the following
+command:
 
 ```
 choco install make llvm clang go

--- a/hugo/content/tools/_index.md
+++ b/hugo/content/tools/_index.md
@@ -88,6 +88,9 @@ choco install make llvm clang go
 We provide a container image which has all the above packages and
 tools already installed for use with Podman or Docker.
 
+{{< tabs >}}
+{{< tab "Linux" >}}
+
 This assumes a working rootless Podman. On Ubuntu 22.10, running
 
 ```
@@ -95,6 +98,40 @@ sudo apt install podman rootlesskit slirp4netns
 ```
 
 should be enough to get you a working Podman setup.
+
+{{< /tab >}}
+{{< tab "macOS" >}}
+Podman for macOS is distributed using brew.
+```
+brew install podman
+```
+
+Next, create and start your first Podman machine:
+
+```
+podman machine init
+podman machine start
+```
+
+You can then verify the installation information using:
+
+```
+podman info
+```
+
+It is also possible to use binaries or a pkginstaller on Podman's
+[Github release page](https://github.com/containers/podman/releases).
+
+{{< /tab >}}
+{{< tab "Windows" >}}
+To install on Windows is a bit more compliacted, follow this link for
+comprehensive instructions:
+
+https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md
+
+{{< /tab >}}
+{{< /tabs >}}
+
 
 You can use the following command to fetch the image:
 


### PR DESCRIPTION
- macOS: instructions to install toolchain and podman
- Windows: Included link to install podman
- Fixed missing include-hierarchy for led.h in example-app 