### PR TITLE
Simplify instructions for TKey Unlocked.

### DIFF
--- a/hugo/content/unlocked/_index.md
+++ b/hugo/content/unlocked/_index.md
@@ -11,7 +11,8 @@ configuration, i.e., it does not have a bitstream programmed. This
 means that you can provision the TKey yourself and then either: 1) use
 it as your everyday security key or 2) use it for hardware or firmware
 development and re-provision as you go. These pages aims to provide
-the tools and instructions needed to provision a TKey.
+the tools and instructions needed to provision the latest release of a
+TKey.
 
 <img src="../images/tp1-tkey-min.png" alt="TKey Unlocked in tp1" title="TKey Unlocked in tp1" width="85%">
 
@@ -84,13 +85,13 @@ Unlocked.
 ## Arrival of Tkey
 When a Tkey Unlocked is sent from Tillitis, it will contain an [LED
 blink design](https://github.com/tillitis/tillitis-key1/tree/main/hw/production_test/application_fpga_test_gateware)
-in the SPI flash. It will blink sequentially in red, green, blue and 
+in the SPI flash. It will blink sequentially in red, green, blue and
 white until you program either the SPI flash or the NVCM. This happens
 to be the last step of our production test suite and is a method for
 you to know that the device in your hand has passed those tests.
 
 It is recommended to power up the TKey once it is recieved to control this
-behavior. If your device does not blink, you should contact Tillitis. 
+behavior. If your device does not blink, you should contact Tillitis.
 
 {{< hint info >}}
 **NOTE:**

--- a/hugo/content/unlocked/build.md
+++ b/hugo/content/unlocked/build.md
@@ -35,51 +35,55 @@ podman machine start
 ```
 
 ## 2. Download the repository
-Download and unzip or clone the repository
+It is **highly recommended** to use the latest official release,
+especially if you are programming the NVCM.
 
-https://github.com/tillitis/tillitis-key1/releases/tag/TK1-23.03.2
+Download and unpack, or clone the repository
 
-It is **highly recommended** to use an official release, especially if
-you are programming the NVCM.
+https://github.com/tillitis/tillitis-key1/releases
+
 
 All the paths in the instructions below are relative to where you
-unpacked the distribution or cloned the repo, so add a `TK1-23.03.2`
-or a `tillitis-key1` as necessary to the paths.
+unpacked the distribution or cloned the repo, so add the tag of the
+downloaded release, like `TK1-24.03`, or a `tillitis-key1` as
+necessary to the paths.
+
+Open a terminal and move into the `tillitis-key1` directory.
 
 ## 3. Start the container {#start-container}
 
-If you're not going with the native tools, start the container by
+If you're not going with the native tools, start the container:
 
 {{< tabs >}}
 {{< tab "Linux" >}}
-First inserting the TKey Programmer into your computer
-```
-podman run --rm --device /dev/bus/usb/$(lsusb | grep -m 1 1209:8886 | awk '{ printf "%s/%s", $2, substr($4,1,3) }') -v .:/build:Z -w /build -it ghcr.io/tillitis/tkey-builder:2 /usr/bin/bash
-```
 
-Note that for this to work, you need permission to speak to the raw USB
-device of the TKey Programmer. See [Linux device
-permissions](tp1/#linux-permissions).
-
-If you're on an SELinux system you might need to run this first to be
-able to access USB devices from the container:
+If you have `make` installed, use our make target
 
 ```
-setsebool container_use_devices=true
+make -C contrib run
+```
+or use this podman command
+```
+podman run --rm --mount type=bind,source="$(pwd)",target=/src -w /src -it ghcr.io/tillitis/tkey-builder:4 /usr/bin/bash
 ```
 
 {{< /tab >}}
 {{< tab "macOS" >}}
 
-```
-podman run --rm --mount type=bind,source="$(pwd)",target=/src -w /src -it ghcr.io/tillitis/tkey-builder:2 /usr/bin/bash
-```
+If you have `make` installed, use our make target
 
+```
+make -C contrib run
+```
+or use this podman command
+```
+podman run --rm --mount type=bind,source="$(pwd)",target=/src -w /src -it ghcr.io/tillitis/tkey-builder:4 /usr/bin/bash
+```
 {{< /tab >}}
 {{< tab "Windows" >}}
 
 ```
-podman run --rm --mount type=bind,source="./",target=/src -w /src -it ghcr.io/tillitis/tkey-builder:2 /usr/bin/bash
+podman run --rm --mount type=bind,source="./",target=/src -w /src -it ghcr.io/tillitis/tkey-builder:4 /usr/bin/bash
 ```
 
 {{< /tab >}}
@@ -117,8 +121,7 @@ standardised key derivation function, HKDF[^3], which derives the UDS.
 Extract-and-Expand Key Derivation Function (HKDF)", RFC 5869, DOI 10.17487/RFC5869, May 2010, <https://www.rfc-editor.org/info/rfc5869>.
 
 ```
-cd hw/application_fpga/
-make secret
+make -C hw/application_fpga secret
 ```
 
 Note that if running outside a container, you need Python installed.
@@ -145,8 +148,7 @@ secrets](unlocked/nvcm/#3-remove-traces-of-build).
 ## 5. Build the bitstream
 
 ```
-cd hw/application_fpga/
-make application_fpga.bin
+make -C hw/application_fpga application_fpga.bin
 
 ```
 

--- a/hugo/content/unlocked/nvcm.md
+++ b/hugo/content/unlocked/nvcm.md
@@ -93,7 +93,6 @@ https://github.com/tillitis/pynvcm
 Navigate to `pynvcm/`
 
 Install the Python interpreter and it's depencencies
-Navigate to `/tillitis-key1/hw/production_tests/` and run
 
 ```
 brew install python3.10
@@ -184,18 +183,23 @@ programmer.
 It is important to remove all traces of the UDS.
 
 To remove your previously created UDS, you have a few choices. Either
-remove the files
+remove these files, with for example `rm`:
 
 ```
 hw/application_fpga/application_fpga.bin
+hw/application_fpga/application_fpga.asc
+hw/application_fpga/application_fpga_par.json
+hw/application_fpga/synth.v
+hw/application_fpga/synth.json
 hw/application_fpga/data/uds.hex
 ```
 
-or natively, or in your container window:
+or natively or your container shell:
 
 ```
 cd hw/application_fpga
 make clean
+rm data/uds.hex
 ```
 
 Once you are done, continue to [casing](unlocked/casing) to assemble

--- a/hugo/content/unlocked/spiflash.md
+++ b/hugo/content/unlocked/spiflash.md
@@ -22,6 +22,9 @@ Programming the SPI flash is done in two steps:
 {{< tabs "flash SPI" >}}
 {{< tab "Linux" >}}
 
+The SPI flash can be programmed either in the container or natively.
+If you are using our container you can go directly to step 2.
+
 ## 1. Download tools
 
 When programming the SPI flash we are using `iceprog` from our fork of
@@ -46,23 +49,40 @@ includes our version of `iceprog` for use with Podman.
 First ensure that the TKey is inserted into the TKey Programmer and
 that the programmer is inserted into your computer.
 
+Note for this to work, you need permission to speak to the raw USB
+device of the TKey Programmer. See [Linux device
+permissions](tp1/#linux-permissions).
+
 ### Podman
 
-Make sure you have the `tkey-builder` container running as outlined in
-[Start the container](unlocked/build/#start-container).
+If you're on an SELinux system you might need to run this first to be
+able to access USB devices from the container:
+
+```
+setsebool container_use_devices=true
+```
+
+The simplest way is to use the make target
+
+```
+make -C contrib flash
+```
+
+which will start the container and program the SPI flash directly. If
+this succeeds you are done and can skip the remaining steps.
+Otherwise start the container using:
+
+```
+podman run --rm --device /dev/bus/usb/$(lsusb | grep -m 1 1209:8886 | awk '{ printf "%s/%s", $2, substr($4,1,3) }') -v .:/build:Z -w /build -it ghcr.io/tillitis/tkey-builder:4 /usr/bin/bash
+```
 
 ### Programming
 
 In a native shell or your container shell:
 
 ```
-cd hw/application_fpga
-tillitis-iceprog application_fpga.bin
+tillitis-iceprog hw/application_fpga/application_fpga.bin
 ```
-
-Note that your own user need permission to speak to the raw USB device
-of the TKey Programmer. See [Linux device
-permissions](tp1/#linux-permissions).
 
 {{< /tab >}}
 {{< tab "macOS" >}}
@@ -94,8 +114,7 @@ that the programmer is inserted into your computer.
 After installing `tillitis-iceprog`, run:
 
 ```
-cd hw/application_fpga
-tillitis-iceprog application_fpga.bin
+tillitis-iceprog hw/application_fpga/application_fpga.bin
 ```
 
 {{< /tab >}}


### PR DESCRIPTION
- Include make targets in contrib
- Point to the latest release, not a specific one
- Remove some minor errors

Linux: moved the "special" way of starting the container (with TP1 mounted) to only the SPI flashing page, which made it possible to use our make target to start the container for building, and since we do have a make target for flashing, which will starts the container with the TP1 mounted, I thought it made sense. 

For future releases I think it makes sense for us to provide some sort of script, or more make targets, that simplifies this. It would be nice if it checked that the necessary tools are in path and made the calls needed, so one only have to do one, maybe two command line calls. 