### PR TITLE
Explain firmware probe and add load sequence diagram

### DIFF
--- a/hugo/content/protocol/_index.md
+++ b/hugo/content/protocol/_index.md
@@ -45,7 +45,7 @@ The bits in the command header byte should be interpreted as:
 
   0. Reserved
   1. HW in application_fpga (unused)
-  2. FW
+  2. Firmware
   3. Device application
 
 * Bit [2] (1 bit). Unused. MUST be zero.
@@ -69,16 +69,16 @@ the command.
 ### Command Frame Examples
 
 Note that most of the examples below do not take into account that the
-particular app or FW command request typically occupies the first byte
-in the data (following the frame header byte), which makes 1 byte less
-available for actual command content.
+particular app or firmware command request typically occupies the
+first byte in the data (following the frame header byte), which makes
+1 byte less available for actual command content.
 
 These examples clarify endpoints and commands using the framing
 protocol:
 
-* 0x13: A command to the FW with 128 bytes of data. The data could,
-  for example, be parts of an application binary to be loaded into
-  memory.
+* 0x13: A command to the firmware with 128 bytes of data. The data
+  could, for example, be parts of an application binary to be loaded
+  into memory.
 
 * 0x1a: A command to the application running with 32 bytes of data.
   The data could be a 32 byte challenge to be signed using the private
@@ -97,7 +97,7 @@ The bits in the response header byte should be interpreted as follows:
 
   0. Reserved
   1. HW in application_fpga (unused)
-  2. FW
+  2. Firmware
   3. Device application
 
 * Bit [2] (1 bit). Response status.
@@ -124,12 +124,12 @@ in the header of the command being responded to.
 ### Response Frame Examples
 
 Note that most of the examples below do not take into account that the
-particular app or FW response request typically occupies the first byte
-in the data (following the frame header byte), which makes 1 byte less
-available for actual response content.
+particular app or firmware response request typically occupies the
+first byte in the data (following the frame header byte), which makes
+1 byte less available for actual response content.
 
-* 0x14: An unsuccessful command to the FW which responds with a single
-  byte of data.
+* 0x14: An unsuccessful command to the firmware which responds with a
+  single byte of data.
 
 * 0x1b: A successful command to the device application running. The
   response contains 128 bytes of data, for example an EdDSA Ed25519

--- a/hugo/content/protocol/_index.md
+++ b/hugo/content/protocol/_index.md
@@ -46,7 +46,7 @@ The bits in the command header byte should be interpreted as:
   0. Reserved
   1. HW in application_fpga (unused)
   2. FW
-  3. SW (device application)
+  3. Device application
 
 * Bit [2] (1 bit). Unused. MUST be zero.
 
@@ -98,7 +98,7 @@ The bits in the response header byte should be interpreted as follows:
   0. Reserved
   1. HW in application_fpga (unused)
   2. FW
-  3. SW (device application)
+  3. Device application
 
 * Bit [2] (1 bit). Response status.
 

--- a/hugo/content/protocol/_index.md
+++ b/hugo/content/protocol/_index.md
@@ -144,11 +144,11 @@ protocol above.
 
 The commands look like this:
 
-| *Name*           | *Size (bytes)* | *Comment*                                |
-|------------------|----------------|------------------------------------------|
+| *Name*           | *Size (bytes)* | *Comment*                                                          |
+|------------------|----------------|--------------------------------------------------------------------|
 | Header           | 1              | Framing protocol header including length of the rest of the frame. |
-| Command/Response | 1              | Any of the below commands or responses.  |
-| Data             | n              | Any additional data.                     |
+| Command/Response | 1              | Any of the below commands or responses.                            |
+| Data             | n              | Any additional data.                                               |
 
 The responses might include a one byte status field where 0 is
 `STATUS_OK` and 1 is `STATUS_BAD`.
@@ -260,6 +260,36 @@ host <-
 ```
 
 #### Load an application
+
+It's recommended to check if the TKey is in firmware mode before
+attempting to load a device application. Typically this firmware probe
+is implemented by sending `FW_CMD_NAME_VERSION` with a header byte
+indicating endpoint 2, firmware.
+
+We encourage device app developers to support a firmware probe and
+reply `NOK` to anything that comes with a header byte for endpoint 2.
+
+The sequence looks like this:
+
+{{< mermaid class="optional" >}}
+sequenceDiagram
+	autonumber
+
+	participant c as Client
+	participant t as TKey
+
+	c->>t: Running firmware?
+	t->>c: Yes!
+	c->>t: FW_CMD_LOAD_APP(size, USS)
+    t->>c: FW_RSP_LOAD_APP
+
+        loop Until entire device app sent
+        	c->>t: FW_CMD_LOAD_APP_DATA(app block)
+            t->>c: FW_RSP_LOAD_APP_DATA || FW_RSP_LOAD_APP_DATA_READY
+        end
+{{< /mermaid >}}
+
+In detail, after the firmware probe:
 
 ```
 host ->


### PR DESCRIPTION
When loading an app, we encourage client app developers to do a firmware probe first.

To explain loading an app clearer, illustrate with a diagram.

Not sure where to place the information about the firmware probe. Perhaps higher up? Or mention it higher up as well?