### PR TITLE
Deprecate the API for configuring the UART core

### DIFF
--- a/hugo/content/hw/_index.md
+++ b/hugo/content/hw/_index.md
@@ -144,19 +144,17 @@ If you want to stop the timer, set bit 1 in `TK1_MMIO_TIMER_CTRL`.
 
 A standard UART (Universal Asynchronous Receiver/Transmitter)
 interface is used for sending and receiving bytes to a TKey device app
-via the interface microcontroller on the TKey. The UART default
-configuration is:
+via the interface microcontroller on the TKey. The UART configuration is:
+- baudrate: 62500 bps
+- data bits: 8
+- stop bit: 1
+- parity: none
 
-| *Config*  | *Default* | *Comment*        |
-|-----------|-----------|------------------|
-| Data rate | 62500 bps | Divisor = 288    |
-| Data bits | 8         |                  |
-| Stop bits | 1         | 0, 1, 2          |
-| Parity    | none      | not configurable |
-
-
-All configuration, except for parity, can be configured by the device
-app. Note that the client app must set the same configuration.
+Note that the client app must set the same configuration. Configuring
+the UART core's baudrate, bit rate and stop bits, in runtime, is
+deprecated and should not be altered by an app. This is to ensure
+compatibility and prevent mismatch between different TKeys, the
+correct baudrate is set during build.
 
 The UART contains a 512-byte Rx-FIFO with status (data available).
 
@@ -169,11 +167,7 @@ Writing is done by polling `TK1_MMIO_UART_TX_STATUS` until it is
 non-zero. The byte to transmit can then be written to the LSB of the
 `TK1_MMIO_UART_TX_DATA` word.
 
-The data bits and stop bits can be set by writing to
-`TK1_MMIO_UART_DATA_BITS` and `TK1_MMIO_UART_STOP_BITS`.
-
-The speed is set by setting a divisor of the bps wanted. Calculate
-divisor = 18E6 / bps. Write the divisor to `TK1_MMIO_UART_BIT_RATE`.
+See `proto.c` in tkey-libs.
 
 ## True Random Number Generator (TRNG)
 

--- a/hugo/content/memory/_index.md
+++ b/hugo/content/memory/_index.md
@@ -74,9 +74,6 @@ access, **i** means invisible.
 | `TK1_MMIO_TIMER_TIMER`       | 0xc100002c     | r/w  | r/w   | Timer init or current value while running. Write blocked when running.                                                                             |
 | `TK1_MMIO_UDS_FIRST`         | 0xc2000040     | r    | i     | First word of Unique Device Secret key. 8 words. Word access only. **Note:** Only readable once per power up.                                      |
 | `TK1_MMIO_UDS_LAST`          | 0xc200005c     | r    | i     | Last word of the UDS. **Note:** Only readable once per power up.                                                                                   |
-| `TK1_MMIO_UART_BIT_RATE`     | 0xc3000040     | r/w  | r/w   | Default 288 (62 500 bps). The bitrate is set by writing the divisor, calculated by: divisor = 18E6 / bps.                                          |
-| `TK1_MMIO_UART_DATA_BITS`    | 0xc3000044     | r/w  | r/w   | Default 8.                                                                                                                                         |
-| `TK1_MMIO_UART_STOP_BITS`    | 0xc3000048     | r/w  | r/w   | Default 1.                                                                                                                                         |
 | `TK1_MMIO_UART_RX_STATUS`    | 0xc3000080     | r    | r     | Non-zero when there is data to read.                                                                                                               |
 | `TK1_MMIO_UART_RX_DATA`      | 0xc3000084     | r    | r     | Data to read. Only the LSB of the word contains data.                                                                                              |
 | `TK1_MMIO_UART_RX_BYTES`     | 0xc3000088     | r    | r     | Number of unread bytes received from client.                                                                                                       |


### PR DESCRIPTION
## Description
Deprecate the API for configuring the UART core

Fixes # (issues)

## Type of change
- [x] Documentation (a change to documentation)
