### PR TITLE
Fix spelling and removing year in footer

### DIFF
--- a/hugo/content.castor/syscalls/_index.md
+++ b/hugo/content.castor/syscalls/_index.md
@@ -14,8 +14,8 @@ wrappers in [tkey-libs](https://github.com/tillitis/tkey-libs/)
 Reset the TKey. Leave the reset type (`enum reset_start`) in `rst` as
 well as an optional `app_digest`, forcing firmware to only allow that
 specific app digest, as well as some data to leave to the next app in
-chain in `next_app_data`. Send the length of the `next_app_data` in
-`len`.
+the chain in `next_app_data`. Send the length of the `next_app_data`
+in `len`.
 
 Typically doesn't return. The TKey is reset and firmware starts again.
 

--- a/hugo/content.castor/tools/_index.md
+++ b/hugo/content.castor/tools/_index.md
@@ -433,7 +433,7 @@ use case is for example to test how Windows would interact with a
 physical TKey that present itself as a CDC device, FIDO token or CCID
 device.
 
-When running the loppback device app, all data coming in on the USB
+When running the loopback device app, all data coming in on the USB
 endpoints CDC, FIDO, or CCID on the physical TKey will be sent out on
 the DEBUG endpoint back to the client. If you want to, you can listen
 on the DEBUG endpoint, forward the data over a network to a QEMU on

--- a/hugo/layouts/partials/docs/footer.html
+++ b/hugo/layouts/partials/docs/footer.html
@@ -1,7 +1,7 @@
 <footer class="text-center">
   <div>
     <p>
-      &copy; Copyright 2024, Tillitis AB.
+      &copy; Copyright, Tillitis AB.
       <br>
       Licensed under
       <a href="https://github.com/tillitis/dev-tillitis/blob/main/LICENSE.txt">CC-BY-SA-4.0 </a>


### PR DESCRIPTION
## Description

Just some spelling and fixing issue #63, removing the year from the copyright statement.
## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Documentation (a change to documentation)

