### PR TITLE
Change link to supported applications

### DIFF
--- a/hugo/content.bellatrix/projects/_index.md
+++ b/hugo/content.bellatrix/projects/_index.md
@@ -42,4 +42,5 @@ This page can be used both as inspiration and to find useful use cases for your 
   Client and device apps for use with the [Sigsum transparency
   log](https://www.sigsum.org/).
 
-Applications officially supported by Tillitis can be found [here](https://tillitis.se/getstarted/#supported-applications-table).
+Applications officially supported by Tillitis can be found
+[here](https://tillitis.se/download/).

--- a/hugo/content.castor/projects/_index.md
+++ b/hugo/content.castor/projects/_index.md
@@ -51,4 +51,4 @@ known nor guaranteed. Check information on each project page.
   log](https://www.sigsum.org/).
 
 Applications officially supported by Tillitis can be found
-[here](https://tillitis.se/getstarted/#supported-applications-table).
+[here](https://tillitis.se/download/).


### PR DESCRIPTION
## Description

The tab with the supported applications table disappeared with the change from Wordpress. The table moved to
https://tillitis.se/download/

## Type of change

- [x] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
