### PR TITLE
Add tillitis-ethereum: TKey-backed Ethereum wallet

### DIFF
--- a/hugo/content.bellatrix/projects/_index.md
+++ b/hugo/content.bellatrix/projects/_index.md
@@ -30,6 +30,9 @@ certifiate authority backed by TKey
   Client and device apps for use with the [Sigsum transparency
   log](https://www.sigsum.org/)
 - [Cryptum: Encrypted file storage](https://github.com/0xMihir/Cryptum)
+- [tillitis-ethereum](https://github.com/monperrus/tillitis-ethereum):
+  Ethereum wallet backed by TKey — hardware-bound key derivation,
+  transaction signing, live verifier flow, and offline two-key ceremony
 
 ## Device applications
 


### PR DESCRIPTION
Add [tillitis-ethereum](https://github.com/monperrus/tillitis-ethereum) to the bellatrix projects list.

This is an Ethereum wallet prototype backed by TKey. The secp256k1 signing key is derived from the TKey CDI inside the device and never exported. The host CLI supports transaction signing, `personal_sign`, EIP-712 typed data, a live verifier flow, and an offline two-key ceremony where both the Tillitis identity key and the Ethereum wallet key sign the same binding statement.